### PR TITLE
feat: add GoogleSQLDatabaseEntityProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "backstage-cli repo lint --since origin/master",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
-    "new": "backstage-cli new --scope internal"
+    "new": "backstage-cli new --scope backtostage"
   },
   "workspaces": {
     "packages": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,6 +33,7 @@
     "@backstage/plugin-search-backend-module-pg": "^0.5.6",
     "@backstage/plugin-search-backend-node": "^1.2.1",
     "@backstage/plugin-techdocs-backend": "^1.6.2",
+    "@backtostage/plugin-catalog-backend-module-gcp": "^0.1.0",
     "app": "link:../app",
     "better-sqlite3": "^8.0.0",
     "dockerode": "^3.3.1",

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -1,5 +1,6 @@
 import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
+import { GoogleSQLDatabaseEntityProvider } from '@backtostage/plugin-catalog-backend-module-gcp'
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -8,6 +9,11 @@ export default async function createPlugin(
 ): Promise<Router> {
   const builder = await CatalogBuilder.create(env);
   builder.addProcessor(new ScaffolderEntitiesProcessor());
+  builder.addEntityProvider(GoogleSQLDatabaseEntityProvider.fromConfig({
+    config: env.config,
+    logger: env.logger,
+    scheduler: env.scheduler
+  }))
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();
   return router;

--- a/plugins/catalog-backend-module-gcp/.eslintrc.js
+++ b/plugins/catalog-backend-module-gcp/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/catalog-backend-module-gcp/README.md
+++ b/plugins/catalog-backend-module-gcp/README.md
@@ -1,0 +1,94 @@
+# Catalog Backend Module for GCP
+
+This is an extension module to the plugin-catalog-backend plugin, providing extensions targeted at GCP.
+
+## Getting started
+
+You will have to add the provider in the catalog initialization code of your
+backend. They are not installed by default, therefore you have to add a
+dependency on `@backtostage/plugin-catalog-backend-module-gcp` to your backend
+package.
+
+```bash
+# From your Backstage root directory
+yarn add --cwd packages/backend @backtostage/plugin-catalog-backend-module-gcp
+```
+
+### Cloud SQL - GoogleSQLDatabaseEntityProvider
+And then add the entity provider to your catalog builder:
+
+```ts title="packages/backend/src/plugins/catalog.ts"
+import { GoogleSQLDatabaseEntityProvider } from '@backtostage/plugin-catalog-backend-module-gcp'
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+  builder.addEntityProvider(
+      GoogleSQLDatabaseEntityProvider.fromConfig({
+      config: env.config,
+      logger: env.logger,
+      // optional: alternatively, use scheduler with schedule defined in app-config.yaml
+      schedule: env.scheduler.createScheduledTaskRunner({
+        frequency: { minutes: 30 },
+        timeout: { minutes: 3 },
+      }),
+      // optional: alternatively, use schedule
+      scheduler: env.scheduler,
+    }),
+  );
+
+  // ..
+}
+```
+
+## Configuration
+
+To use this provider, you'll need a [Google Service Account](https://cloud.google.com/iam/docs/service-account-overview).
+Once generated, store the path to this file in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. 
+
+
+You can find more details about this in the [official docs](https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest#impersonated-credentials-client)
+
+Then you can add a `gcp` config to the catalog providers configuration:
+
+```yaml
+catalog:
+  providers:
+    gcp:
+      # the project id need to be the GCP Project where your Resources are present
+      project:
+        ownerLabel: 'team' # string
+        componentLabel: 'app' # string
+        resourceType: 'SQL' # string
+        schedule: # optional; same options as in TaskScheduleDefinition
+          # supports cron, ISO duration, "human duration" as used in code
+          frequency: { minutes: 30 }
+          # supports ISO duration, "human duration" as used in code
+          timeout: { minutes: 3 }
+```
+
+This provider supports multiple projects using different names at the root level.
+
+- **`project`** _(required)_:
+  Project ID of the project for which to list Cloud SQL instances.
+- **`ownerLabel`** _(optional)_:
+  - Default: `owner`. 
+  - The provider will look for user defined labels to find the [Resource Owner](https://backstage.io/docs/features/software-catalog/descriptor-format#specowner-required-2). 
+  - You can provide the label name where the owner name is present, if the label isn't present the owner will be set `unknown`.
+- **`componentLabel`** _(optional)_:
+  - Default: `component`. 
+  - The provider will look for user defined labels to find the Resource [dependencyOf](https://backstage.io/docs/features/software-catalog/well-known-relations#dependson-and-dependencyof). 
+  - You can provide the label name where the component name is present, if the label isn't present `dependencyOf` will be skipped.
+- **`resourceType`** _(optional)_:
+  - Default: `CloudSQL`. 
+  - The provider will set the [`type`](https://backstage.io/docs/features/software-catalog/descriptor-format#spectype-required-4) based in this information.
+- **`schedule`** _(optional)_:
+    - **`frequency`**:
+      How often you want the task to run. The system does its best to avoid overlapping invocations.
+    - **`timeout`**:
+      The maximum amount of time that a single task invocation can take.
+    - **`initialDelay`** _(optional)_:
+      The amount of time that should pass before the first invocation happens.
+    - **`scope`** _(optional)_:
+      `'global'` or `'local'`. Sets the scope of concurrency control.

--- a/plugins/catalog-backend-module-gcp/package.json
+++ b/plugins/catalog-backend-module-gcp/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@backtostage/plugin-catalog-backend-module-gcp",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-common": "^0.18.5",
+    "@backstage/config": "^1.0.7",
+    "@types/express": "*",
+    "@types/uuid": "^9.0.2",
+    "express": "^4.17.1",
+    "express-promise-router": "^4.1.0",
+    "googleapis": "^118.0.0",
+    "node-fetch": "^2.6.7",
+    "uuid": "^9.0.0",
+    "winston": "^3.2.1",
+    "yn": "^4.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.22.7",
+    "@types/supertest": "^2.0.12",
+    "msw": "^1.0.0",
+    "supertest": "^6.2.4"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/catalog-backend-module-gcp/src/index.ts
+++ b/plugins/catalog-backend-module-gcp/src/index.ts
@@ -1,0 +1,1 @@
+export {GoogleSQLDatabaseEntityProvider} from "./providers/GoogleSQLDatabaseEntityProvider";

--- a/plugins/catalog-backend-module-gcp/src/lib/sqladmin.ts
+++ b/plugins/catalog-backend-module-gcp/src/lib/sqladmin.ts
@@ -1,0 +1,33 @@
+import {google, sqladmin_v1beta4} from "googleapis";
+
+const sqlAdmin = google.sqladmin('v1beta4');
+
+export async function listSQLInstances(project: string) {
+
+    const client = await google.auth.getClient({
+        scopes: [
+            'https://www.googleapis.com/auth/cloud-platform',
+            'https://www.googleapis.com/auth/sqlservice.admin']
+    })
+
+    const request: sqladmin_v1beta4.Params$Resource$Instances$List = {
+        project: project,
+        auth: client,
+    };
+
+    const dbs: sqladmin_v1beta4.Schema$DatabaseInstance[] = []
+    do {
+        const response = await sqlAdmin.instances.list(request);
+        if (!response) return []
+        const result = response.data
+
+        const itemsPage = result.items;
+        if (!itemsPage) {
+            return [];
+        }
+        dbs.push(...itemsPage)
+        request.pageToken = result.nextPageToken ?? undefined;
+    } while (request.pageToken)
+
+    return dbs;
+}

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
@@ -1,0 +1,208 @@
+import {GoogleSQLDatabaseEntityProvider} from "./GoogleSQLDatabaseEntityProvider";
+import {TaskInvocationDefinition, TaskRunner,} from '@backstage/backend-tasks';
+import {ConfigReader} from '@backstage/config';
+import {getVoidLogger} from '@backstage/backend-common';
+import {EntityProviderConnection} from "@backstage/plugin-catalog-node";
+import * as helpers from '../lib/sqladmin';
+import {ANNOTATION_LOCATION, ANNOTATION_ORIGIN_LOCATION} from "@backstage/catalog-model";
+
+
+jest.mock('../lib/sqladmin', () => {
+    return {
+        listSQLInstances: jest.fn(),
+    };
+});
+
+class PersistingTaskRunner implements TaskRunner {
+    private tasks: TaskInvocationDefinition[] = [];
+
+    getTasks() {
+        return this.tasks;
+    }
+
+    run(task: TaskInvocationDefinition): Promise<void> {
+        this.tasks.push(task);
+        return Promise.resolve(undefined);
+    }
+}
+
+const logger = getVoidLogger();
+describe('GoogleSQLDatabaseEntityProvider', () => {
+    afterEach(() => jest.resetAllMocks());
+
+    it('should be defined', () => {
+        expect(GoogleSQLDatabaseEntityProvider).toBeDefined()
+    })
+
+
+    it('no provider config', () => {
+        const schedule = new PersistingTaskRunner();
+        const config = new ConfigReader({});
+        const providers = GoogleSQLDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            schedule,
+        });
+
+        expect(providers).toHaveLength(0);
+    });
+
+    it('single simple provider config', () => {
+        const schedule = new PersistingTaskRunner();
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: {
+                        project: {},
+                    },
+                },
+            },
+        });
+        const providers = GoogleSQLDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            schedule,
+        });
+
+        expect(providers).toHaveLength(1);
+        expect(providers[0].getProviderName()).toEqual('GoogleSQLDatabaseEntityProvider:project');
+    });
+
+    it('multiple provider configs', () => {
+        const schedule = new PersistingTaskRunner();
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: {
+                        myProvider: {},
+                        anotherProvider: {},
+                    },
+                },
+            },
+        });
+        const providers = GoogleSQLDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            schedule,
+        });
+
+        expect(providers).toHaveLength(2);
+        expect(providers[0].getProviderName()).toEqual(
+            'GoogleSQLDatabaseEntityProvider:myProvider',
+        );
+        expect(providers[1].getProviderName()).toEqual(
+            'GoogleSQLDatabaseEntityProvider:anotherProvider',
+        );
+    });
+
+    it('apply full update on scheduled execution with simple config', async () => {
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: {
+                        myProvider: {},
+                    },
+                },
+            },
+        });
+        const schedule = new PersistingTaskRunner();
+        const entityProviderConnection: EntityProviderConnection = {
+            applyMutation: jest.fn(),
+            refresh: jest.fn(),
+        };
+
+        const provider = GoogleSQLDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            schedule,
+        })[0];
+
+        const mockListSQLInstances = jest.spyOn(
+            helpers,
+            'listSQLInstances',
+        );
+
+        mockListSQLInstances.mockReturnValue(
+            Promise.resolve([
+                {
+                    name: 'database-name',
+                    settings: {
+                        userLabels: {
+                            owner: 'owner',
+                            component: 'my-service',
+                        }
+                    }
+                },
+                {
+                    name: 'another-database-name',
+                    settings: {
+                        userLabels: {
+                            owner: 'owner2',
+                            component: 'my-other-service',
+                        }
+                    }
+                }
+            ]),
+        );
+
+        await provider.connect(entityProviderConnection);
+
+        const taskDef = schedule.getTasks()[0];
+        expect(taskDef.id).toEqual('GoogleSQLDatabaseEntityProvider:myProvider:refresh');
+        await (taskDef.fn as () => Promise<void>)();
+
+        const expectedEntities = [
+            {
+                entity: {
+                    kind: 'Resource',
+                    apiVersion: 'backstage.io/v1alpha1',
+                    metadata: {
+                        annotations: {
+                            [ANNOTATION_LOCATION]: `GoogleSQLDatabaseEntityProvider:myProvider`,
+                            [ANNOTATION_ORIGIN_LOCATION]: `GoogleSQLDatabaseEntityProvider:myProvider`,
+                        },
+                        name: 'database-name',
+                        title: "database-name",
+                    },
+                    spec: {
+                        dependencyOf: [
+                            'component:my-service'
+                        ],
+                        owner: 'owner',
+                        type: 'CloudSQL'
+                    }
+                },
+                locationKey: 'GoogleSQLDatabaseEntityProvider:myProvider',
+            },
+            {
+                entity: {
+                    kind: 'Resource',
+                    apiVersion: 'backstage.io/v1alpha1',
+                    metadata: {
+                        annotations: {
+                            [ANNOTATION_LOCATION]: `GoogleSQLDatabaseEntityProvider:myProvider`,
+                            [ANNOTATION_ORIGIN_LOCATION]: `GoogleSQLDatabaseEntityProvider:myProvider`,
+                        },
+                        name: 'another-database-name',
+                        title: "another-database-name",
+                    },
+                    spec: {
+                        dependencyOf: [
+                            'component:my-other-service'
+                        ],
+                        owner: 'owner2',
+                        type: 'CloudSQL'
+                    }
+                },
+                locationKey: 'GoogleSQLDatabaseEntityProvider:myProvider',
+            }
+
+        ];
+
+        expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
+        expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+            type: 'full',
+            entities: expectedEntities,
+        });
+    });
+});

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.ts
@@ -1,0 +1,92 @@
+import {EntityProvider, EntityProviderConnection,} from '@backstage/plugin-catalog-node';
+import {Logger} from "winston";
+import {Config} from "@backstage/config";
+import {GoogleSQLDatabaseEntityProviderConfig, readProviderConfigs} from "./GoogleSQLDatabaseEntityProviderConfig";
+import {GoogleDatabaseResourceTransformer} from "../transformers/defaultResourceTransformer";
+import {PluginTaskScheduler, TaskRunner} from '@backstage/backend-tasks';
+import * as uuid from "uuid";
+import {listSQLInstances} from "../lib/sqladmin";
+
+
+export class GoogleSQLDatabaseEntityProvider implements EntityProvider {
+    private readonly logger: Logger;
+    private readonly scheduleFn: () => Promise<void>;
+    private connection?: EntityProviderConnection;
+
+    static fromConfig(options: {
+        config: Config,
+        resourceTransformer?: GoogleDatabaseResourceTransformer,
+        logger: Logger,
+        schedule?: TaskRunner;
+        scheduler?: PluginTaskScheduler;
+    }) {
+        if (!options.schedule && !options.scheduler) {
+            throw new Error('Either schedule or scheduler must be provided.');
+        }
+
+        return readProviderConfigs(options).map((providerConfig) => {
+            const taskRunner =
+                options.schedule ??
+                options.scheduler!.createScheduledTaskRunner(providerConfig.schedule!);
+
+            return new GoogleSQLDatabaseEntityProvider(providerConfig, taskRunner, options.logger)
+        })
+    }
+
+    constructor(private config: GoogleSQLDatabaseEntityProviderConfig, taskRunner: TaskRunner, logger: Logger) {
+        this.scheduleFn = this.createScheduleFn(taskRunner);
+        this.logger = logger.child({
+            target: this.getProviderName(),
+        });
+    }
+
+    async connect(connection: EntityProviderConnection): Promise<void> {
+        this.connection = connection;
+        return await this.scheduleFn();
+    }
+
+
+    getProviderName(): string {
+        return `GoogleSQLDatabaseEntityProvider:${this.config.project}`;
+    }
+
+    async refresh(logger: Logger) {
+        if (!this.connection) {
+            throw new Error('Not initialized');
+        }
+        logger.info(`Reading GCP SQL Instances for project ${this.config.project}`);
+        const databases = await listSQLInstances(this.config.project)
+        const resources = databases.map(db => this.config.resourceTransformer(this.config, db));
+
+        await this.connection.applyMutation({
+            type: 'full',
+            entities: resources.map(entity => ({
+                entity,
+                locationKey: this.getProviderName(),
+            })),
+        });
+
+    }
+    private createScheduleFn(taskRunner: TaskRunner): () => Promise<void> {
+        return async () => {
+            const taskId = `${this.getProviderName()}:refresh`;
+            return taskRunner.run({
+                id: taskId,
+                fn: async () => {
+                    const logger = this.logger.child({
+                        class: GoogleSQLDatabaseEntityProvider.prototype.constructor.name,
+                        taskId,
+                        taskInstanceId: uuid.v4(),
+                    });
+                    try {
+                        await this.refresh(logger);
+                    } catch (error) {
+                        logger.error(`${this.getProviderName()} run failed`, error);
+                    }
+                },
+            });
+        };
+    }
+
+}
+

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.test.ts
@@ -1,0 +1,79 @@
+import {ConfigReader} from '@backstage/config';
+import {readProviderConfigs} from "./GoogleSQLDatabaseEntityProviderConfig";
+
+describe('readProviderConfigs', () => {
+    afterEach(() => jest.resetAllMocks());
+
+
+    it('no provider config', () => {
+        const config = new ConfigReader({});
+        const providerConfigs = readProviderConfigs({config});
+
+        expect(providerConfigs).toHaveLength(0);
+    });
+
+    it('single simple provider config', () => {
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: {
+                        'my-project': {},
+                    },
+                },
+            },
+        });
+        const providerConfigs = readProviderConfigs({config});
+
+        expect(providerConfigs).toHaveLength(1);
+        expect(providerConfigs[0].project).toEqual('my-project');
+        expect(providerConfigs[0].ownerLabel).toEqual('owner');
+        expect(providerConfigs[0].componentLabel).toEqual('component');
+        expect(providerConfigs[0].resourceType).toEqual('CloudSQL');
+        expect(providerConfigs[0].resourceTransformer).toBeDefined();
+    });
+
+    it('multiple provider configs', () => {
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: {
+                        'my-project': {},
+                        'my-other-project': {
+                            ownerLabel: 'team',
+                            componentLabel: 'app',
+                            resourceType: 'SQL',
+                            schedule: {
+                                frequency: {minutes: 30},
+                                timeout: {minutes: 3},
+                            },
+                        },
+                    },
+                }
+            },
+        });
+        const providerConfigs = readProviderConfigs({config});
+
+        expect(providerConfigs).toHaveLength(2);
+        expect(providerConfigs[0]).toEqual({
+            project: 'my-project',
+            ownerLabel: 'owner',
+            componentLabel: 'component',
+            resourceType: 'CloudSQL',
+            resourceTransformer: expect.any(Function)
+        });
+
+        expect(providerConfigs[1]).toEqual({
+            project: 'my-other-project',
+            ownerLabel: 'team',
+            componentLabel: 'app',
+            resourceType: 'SQL',
+            resourceTransformer: expect.any(Function),
+            schedule: {
+                frequency: { minutes: 30},
+                timeout: { minutes: 3 },
+            },
+        });
+
+    });
+
+})

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.ts
@@ -1,0 +1,59 @@
+import {Config} from "@backstage/config";
+import {
+    defaultDatabaseResourceTransformer,
+    GoogleDatabaseResourceTransformer
+} from "../transformers/defaultResourceTransformer";
+import {
+    readTaskScheduleDefinitionFromConfig,
+    TaskScheduleDefinition,
+} from '@backstage/backend-tasks';
+
+export type GoogleSQLDatabaseEntityProviderConfig = {
+    project: string
+    ownerLabel: string
+    componentLabel: string
+    resourceType: string
+    resourceTransformer: GoogleDatabaseResourceTransformer
+    schedule?: TaskScheduleDefinition;
+}
+
+export function readProviderConfigs(options: {
+    config: Config,
+    resourceTransformer?: GoogleDatabaseResourceTransformer
+}): GoogleSQLDatabaseEntityProviderConfig[] {
+
+    const providersConfig = options.config.getOptionalConfig('catalog.providers.gcp');
+    if (!providersConfig) {
+        return [];
+    }
+
+    return providersConfig.keys().map(project => {
+        const providerConfig = providersConfig.getConfig(project);
+
+        return readProviderConfig(project, providerConfig, options.resourceTransformer);
+    });
+}
+
+export function readProviderConfig(
+    project: string,
+    config: Config,
+    resourceTransformer?: GoogleDatabaseResourceTransformer
+): GoogleSQLDatabaseEntityProviderConfig {
+    const ownerLabel = config.getOptionalString('ownerLabel') ?? 'owner'
+    const componentLabel = config.getOptionalString('componentLabel') ?? 'component'
+    const resourceType = config.getOptionalString('resourceType') ?? 'CloudSQL'
+
+    const schedule = config.has('schedule')
+        ? readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'))
+        : undefined;
+
+
+    return {
+        project,
+        ownerLabel,
+        componentLabel,
+        resourceType,
+        resourceTransformer: resourceTransformer ?? defaultDatabaseResourceTransformer,
+        schedule
+    }
+}

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
@@ -1,0 +1,137 @@
+import {defaultDatabaseResourceTransformer} from "./defaultResourceTransformer";
+import {GoogleSQLDatabaseEntityProviderConfig} from "../providers/GoogleSQLDatabaseEntityProviderConfig";
+import {sqladmin_v1beta4} from "googleapis";
+import {ANNOTATION_LOCATION, ANNOTATION_ORIGIN_LOCATION} from "@backstage/catalog-model";
+
+describe('defaultDatabaseResourceTransformer', () => {
+    it('should be defined', () => {
+        expect(defaultDatabaseResourceTransformer).toBeDefined()
+    })
+
+    describe('when a Database instance is provided', () => {
+        const config: GoogleSQLDatabaseEntityProviderConfig = {
+            project: 'project',
+            componentLabel: 'component',
+            ownerLabel: 'owner',
+            resourceType: 'SQL',
+            resourceTransformer: defaultDatabaseResourceTransformer
+        }
+
+        const database: sqladmin_v1beta4.Schema$DatabaseInstance = {
+            name: 'database-name',
+            settings: {
+                userLabels: {
+                    [config.ownerLabel]: 'owner',
+                    [config.componentLabel]: 'my-service',
+                }
+            }
+        }
+
+        it('should transform in a resource entity', () => {
+
+            const result = defaultDatabaseResourceTransformer(config, database);
+            expect(result).toEqual({
+                kind: 'Resource',
+                apiVersion: 'backstage.io/v1alpha1',
+                metadata: {
+                    annotations: {
+                        [ANNOTATION_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                    },
+                    name: 'database-name',
+                    title: "database-name",
+                },
+                spec: {
+                    dependencyOf: [
+                        'component:my-service'
+                    ],
+                    owner: 'owner',
+                    type: 'SQL'
+                }
+            })
+        })
+
+        it('should use unknown in a resource entity without label owner defined in database label', () => {
+            const localConfig: GoogleSQLDatabaseEntityProviderConfig = {
+                project: 'project',
+                componentLabel: 'component',
+                ownerLabel: 'ownerNotPresent',
+                resourceType: 'SQL',
+                resourceTransformer: defaultDatabaseResourceTransformer
+            }
+
+            const result = defaultDatabaseResourceTransformer(localConfig, database);
+            expect(result).toEqual({
+                kind: 'Resource',
+                apiVersion: 'backstage.io/v1alpha1',
+                metadata: {
+                    annotations: {
+                        [ANNOTATION_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                    },
+                    name: 'database-name',
+                    title: "database-name",
+                },
+                spec: {
+                    dependencyOf: [
+                        'component:my-service'
+                    ],
+                    owner: 'unknown',
+                    type: 'SQL'
+                }
+            })
+        })
+
+        it('should use empty dependencies in a resource entity without label component defined in database label', () => {
+            const localConfig: GoogleSQLDatabaseEntityProviderConfig = {
+                project: 'project',
+                componentLabel: 'componentNotPresent',
+                ownerLabel: 'owner',
+                resourceType: 'SQL',
+                resourceTransformer: defaultDatabaseResourceTransformer
+            }
+
+            const result = defaultDatabaseResourceTransformer(localConfig, database);
+            expect(result).toEqual({
+                kind: 'Resource',
+                apiVersion: 'backstage.io/v1alpha1',
+                metadata: {
+                    annotations: {
+                        [ANNOTATION_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                    },
+                    name: 'database-name',
+                    title: "database-name",
+                },
+                spec: {
+                    owner: 'owner',
+                    type: 'SQL'
+                }
+            })
+        })
+
+        it('should use empty values in a resource entity without user settings defined in database', () => {
+            const localDatabase: sqladmin_v1beta4.Schema$DatabaseInstance = {
+                name: 'database-name',
+            }
+
+            const result = defaultDatabaseResourceTransformer(config, localDatabase);
+            expect(result).toEqual({
+                kind: 'Resource',
+                apiVersion: 'backstage.io/v1alpha1',
+                metadata: {
+                    annotations: {
+                        [ANNOTATION_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `GoogleSQLDatabaseEntityProvider:${config.project}`,
+                    },
+                    name: 'database-name',
+                    title: "database-name",
+                },
+                spec: {
+                    owner: 'unknown',
+                    type: 'SQL'
+                }
+            })
+        })
+    })
+})

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
@@ -1,0 +1,37 @@
+import {GoogleSQLDatabaseEntityProviderConfig} from "../providers/GoogleSQLDatabaseEntityProviderConfig";
+import {sqladmin_v1beta4} from "googleapis";
+import {ANNOTATION_LOCATION, ANNOTATION_ORIGIN_LOCATION, ResourceEntity} from "@backstage/catalog-model";
+
+export type GoogleDatabaseResourceTransformer = (providerConfig: GoogleSQLDatabaseEntityProviderConfig, database: sqladmin_v1beta4.Schema$DatabaseInstance) => ResourceEntity
+export const defaultDatabaseResourceTransformer: GoogleDatabaseResourceTransformer = (providerConfig: GoogleSQLDatabaseEntityProviderConfig, database: sqladmin_v1beta4.Schema$DatabaseInstance): ResourceEntity => {
+    const annotations: { [name: string]: string } = {
+        [ANNOTATION_LOCATION]: `GoogleSQLDatabaseEntityProvider:${providerConfig.project}`,
+        [ANNOTATION_ORIGIN_LOCATION]: `GoogleSQLDatabaseEntityProvider:${providerConfig.project}`,
+    };
+
+    const owner = database.settings?.userLabels?.[providerConfig.ownerLabel]
+    const component = database.settings?.userLabels?.[providerConfig.componentLabel];
+
+    const resource: ResourceEntity = {
+        kind: 'Resource',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+            annotations,
+            name: database.name!,
+            title: database.name!,
+        },
+        spec: {
+            owner: owner || 'unknown',
+            type: providerConfig.resourceType,
+        }
+    };
+
+    if (component) {
+        resource.spec.dependencyOf = [
+            `component:${component}`
+        ]
+    }
+
+
+    return resource
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5509,6 +5509,28 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
+"@mswjs/cookies@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
+  integrity sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.17.5":
+  version "0.17.9"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.17.9.tgz#0096fc88fea63ee42e36836acae8f4ae33651c04"
+  integrity sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@types/debug" "^4.1.7"
+    "@xmldom/xmldom" "^0.8.3"
+    debug "^4.3.3"
+    headers-polyfill "^3.1.0"
+    outvariant "^1.2.1"
+    strict-event-emitter "^0.2.4"
+    web-encoding "^1.1.5"
+
 "@n1ru4l/push-pull-async-iterable-iterator@^3.1.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-3.2.0.tgz#c15791112db68dd9315d329d652b7e797f737655"
@@ -5949,6 +5971,11 @@
     "@octokit/webhooks-methods" "^3.0.0"
     "@octokit/webhooks-types" "6.11.0"
     aggregate-error "^3.1.0"
+
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@openapi-contrib/openapi-schema-to-json-schema@~3.2.0":
   version "3.2.0"
@@ -6959,6 +6986,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cookiejar@*":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
+  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
+
 "@types/cors@^2.8.6":
   version "2.8.13"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.13.tgz#b8ade22ba455a1b8cb3b5d3f35910fd204f84f94"
@@ -6966,7 +7003,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/debug@^4.0.0":
+"@types/debug@^4.0.0", "@types/debug@^4.1.7":
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
   integrity sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==
@@ -7120,6 +7157,11 @@
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
   integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
+
+"@types/js-levenshtein@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
+  integrity sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==
 
 "@types/js-yaml@^4.0.1":
   version "4.0.5"
@@ -7449,6 +7491,13 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz#b6a955219b54151bfebd4521170723df5e13caad"
+  integrity sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
@@ -7484,6 +7533,21 @@
   integrity sha512-W/iTlIkGEyTBGTEvZCey8EgQlQ5l0DwMqi3iOXlLs2kyBwYTXHKEiU6IZ5EwoRwngL8/dGYuzezSup89ttVHLw==
   dependencies:
     "@types/react" "*"
+
+"@types/superagent@*":
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.18.tgz#e8f037d015cb3b55e64dd00c4d07a84be6d16d34"
+  integrity sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
+
+"@types/supertest@^2.0.12":
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.12.tgz#ddb4a0568597c9aadff8dbec5b2e8fddbe8692fc"
+  integrity sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==
+  dependencies:
+    "@types/superagent" "*"
 
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.14.6"
@@ -7523,6 +7587,11 @@
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
+"@types/uuid@^9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
+  integrity sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==
 
 "@types/webpack-env@^1.15.2":
   version "1.18.1"
@@ -7797,6 +7866,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.11.tgz#adecc134521274711d071d5b0200907cc83b38ee"
   integrity sha512-UDi3g6Jss/W5FnSzO9jCtQwEpfymt0M+sPPlmLhDH6h2TJ8j4ESE/LpmNPBij15J5NKkk4/cg/qoVMdWI3vnlQ==
 
+"@xmldom/xmldom@^0.8.3":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.8.tgz#d0d11511cbc1de77e53342ad1546a4d487d6ea72"
+  integrity sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==
+
 "@xobotyi/scrollbar-width@^1.9.5":
   version "1.9.5"
   resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
@@ -7824,6 +7898,11 @@
   dependencies:
     js-yaml "^3.10.0"
     tslib "^2.4.0"
+
+"@zxing/text-encoding@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -9089,6 +9168,14 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
@@ -9529,6 +9616,11 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
+component-emitter@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
 compress-commons@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d"
@@ -9781,7 +9873,7 @@ cookie@0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
-cookie@0.4.2:
+cookie@0.4.2, cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -9790,6 +9882,11 @@ cookie@0.5.0, cookie@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 copy-to-clipboard@^3.2.0, copy-to-clipboard@^3.3.1:
   version "3.3.3"
@@ -10562,7 +10659,7 @@ detect-port-alt@^1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-dezalgo@^1.0.0:
+dezalgo@^1.0.0, dezalgo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
   integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
@@ -11437,7 +11534,7 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@3.3.0, events@^3.0.0, events@^3.2.0:
+events@3.3.0, events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -11654,7 +11751,7 @@ fast-redact@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-2.1.0.tgz#dfe3c1ca69367fb226f110aa4ec10ec85462ffdf"
   integrity sha512-0LkHpTLyadJavq9sRzzyqIoMZemWli77K2/MGOkafrR64B9ItrvZ9aT+jluvNDsv0YEHjSNhlMBtbokuoqii4A==
 
-fast-safe-stringify@^2.0.6, fast-safe-stringify@^2.0.7:
+fast-safe-stringify@^2.0.6, fast-safe-stringify@^2.0.7, fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
@@ -11959,6 +12056,16 @@ formdata-node@^4.0.0:
   dependencies:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.3"
+
+formidable@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
+  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
+  dependencies:
+    dezalgo "^1.0.4"
+    hexoid "^1.0.0"
+    once "^1.4.0"
+    qs "^6.11.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -12456,6 +12563,26 @@ google-p12-pem@^4.0.0:
   dependencies:
     node-forge "^1.3.1"
 
+googleapis-common@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/googleapis-common/-/googleapis-common-6.0.4.tgz#bd968bef2a478bcd3db51b27655502a11eaf8bf4"
+  integrity sha512-m4ErxGE8unR1z0VajT6AYk3s6a9gIMM6EkDZfkPnES8joeOlEtFEJeF8IyZkb0tjPXkktUfYrE4b3Li1DNyOwA==
+  dependencies:
+    extend "^3.0.2"
+    gaxios "^5.0.1"
+    google-auth-library "^8.0.2"
+    qs "^6.7.0"
+    url-template "^2.0.8"
+    uuid "^9.0.0"
+
+googleapis@^118.0.0:
+  version "118.0.0"
+  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-118.0.0.tgz#a8b9f84d283544b85927abeb989252cb2f3ec490"
+  integrity sha512-Ny6zJOGn5P/YDT6GQbJU6K0lSzEu4Yuxnsn45ZgBIeSQ1RM0FolEjUToLXquZd89DU9wUfqA5XYHPEctk1TFWg==
+  dependencies:
+    google-auth-library "^8.0.2"
+    googleapis-common "^6.0.0"
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -12526,7 +12653,7 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.13.1.tgz#96ac9963edb1e94c8e7f21af48ce5fcaab91779a"
   integrity sha512-eiX7ES/ZQr0q7hSM5UBOEIFfaAUmAY9/CSDyAnsETuybByU7l/v46drRg9DQoTvVABEHp3QnrvwgTRMhqy7zxQ==
 
-graphql@^16.0.0:
+"graphql@^15.0.0 || ^16.0.0", graphql@^16.0.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
@@ -12681,10 +12808,20 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+headers-polyfill@^3.1.0, headers-polyfill@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.1.2.tgz#9a4dcb545c5b95d9569592ef7ec0708aab763fbe"
+  integrity sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==
+
 helmet@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/helmet/-/helmet-6.2.0.tgz#c29d62014be4c70b8ef092c9c5e54c8c26b8e16e"
   integrity sha512-DWlwuXLLqbrIOltR6tFQXShj/+7Cyp0gLi6uAb8qMdFh/YBBFbKSgQ6nbXmScYd8emMctuthmgIa7tUfo9Rtyg==
+
+hexoid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
+  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 highlight.js@^10.4.1, highlight.js@^10.7.2, highlight.js@~10.7.0:
   version "10.7.3"
@@ -13394,6 +13531,11 @@ is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number-object@^1.0.4:
   version "1.0.7"
@@ -14123,6 +14265,11 @@ js-file-download@^0.4.12:
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
   integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -15438,7 +15585,7 @@ meros@^1.1.4:
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.3.0.tgz#c617d2092739d55286bf618129280f362e6242f2"
   integrity sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==
 
-methods@^1.0.0, methods@~1.1.2:
+methods@^1.0.0, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -15749,6 +15896,11 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 mime@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
@@ -16021,6 +16173,31 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+msw@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-1.2.2.tgz#126c3150c07f651e97b24fbd405821f3aeaf9397"
+  integrity sha512-GsW3PE/Es/a1tYThXcM8YHOZ1S1MtivcS3He/LQbbTCx3rbWJYCtWD5XXyJ53KlNPT7O1VI9sCW3xMtgFe8XpQ==
+  dependencies:
+    "@mswjs/cookies" "^0.2.2"
+    "@mswjs/interceptors" "^0.17.5"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/js-levenshtein" "^1.1.1"
+    chalk "4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.2"
+    graphql "^15.0.0 || ^16.0.0"
+    headers-polyfill "^3.1.2"
+    inquirer "^8.2.0"
+    is-node-process "^1.2.0"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.7"
+    outvariant "^1.4.0"
+    path-to-regexp "^6.2.0"
+    strict-event-emitter "^0.4.3"
+    type-fest "^2.19.0"
+    yargs "^17.3.1"
 
 multicast-dns@^7.2.5:
   version "7.2.5"
@@ -16749,6 +16926,11 @@ ospath@^1.2.2:
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
 
+outvariant@^1.2.1, outvariant@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.0.tgz#e742e4bda77692da3eca698ef5bfac62d9fba06e"
+  integrity sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==
+
 p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
@@ -17213,6 +17395,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+
+path-to-regexp@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -18026,7 +18213,7 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.10.1, qs@^6.10.2, qs@^6.11.0, qs@^6.9.1, qs@^6.9.4:
+qs@^6.10.1, qs@^6.10.2, qs@^6.11.0, qs@^6.7.0, qs@^6.9.1, qs@^6.9.4:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
@@ -19326,6 +19513,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
+set-cookie-parser@^2.4.6:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
+  integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
+
 set-harmonic-interval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
@@ -19893,6 +20085,18 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+strict-event-emitter@^0.2.4:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz#b4e768927c67273c14c13d20e19d5e6c934b47ca"
+  integrity sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==
+  dependencies:
+    events "^3.3.0"
+
+strict-event-emitter@^0.4.3:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz#ff347c8162b3e931e3ff5f02cfce6772c3b07eb3"
+  integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
+
 strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
@@ -20127,6 +20331,30 @@ sucrase@^3.20.2:
     mz "^2.7.0"
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
+
+superagent@^8.0.5:
+  version "8.0.9"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.0.9.tgz#2c6fda6fadb40516515f93e9098c0eb1602e0535"
+  integrity sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.4"
+    debug "^4.3.4"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.0"
+    formidable "^2.1.2"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.11.0"
+    semver "^7.3.8"
+
+supertest@^6.2.4:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.3.3.tgz#42f4da199fee656106fd422c094cf6c9578141db"
+  integrity sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^8.0.5"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -20780,6 +21008,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -21084,6 +21317,11 @@ url-parse@^1.5.3, url-parse@^1.5.8:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==
+
 url@^0.11.0, url@~0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.1.tgz#26f90f615427eca1b9f4d6a28288c147e2302a32"
@@ -21365,6 +21603,15 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-encoding@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
+  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
+  dependencies:
+    util "^0.12.3"
+  optionalDependencies:
+    "@zxing/text-encoding" "0.9.0"
 
 web-streams-polyfill@4.0.0-beta.3:
   version "4.0.0-beta.3"


### PR DESCRIPTION
# Description

This PR add the first version to `GoogleSQLDatabaseEntityProvider`. Next iterations will refine this to increment the code before release if needed. 
You can follow the README to configure or use the current backend to test (just setup the GCP Service Account)