### PR TITLE
add redis entity provider

### DIFF
--- a/.changeset/eleven-cherries-destroy.md
+++ b/.changeset/eleven-cherries-destroy.md
@@ -1,0 +1,7 @@
+---
+'@backtostage/plugin-catalog-backend-module-gcp': patch
+---
+
+This change adds a new entity provider to import redis memorystore from GCP
+
+We are using a separete module export to allow more flexibility in each resource you want to import in your backstage instance

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -113,3 +113,15 @@ catalog:
     #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
     #   rules:
     #     - allow: [User, Group]
+  providers:
+    gcp:
+      - project: my-gcp-project-id
+        ownerLabel: team
+        componentLabel: app
+        cloudsql:
+          resourceType: SQL
+        redis:
+          location: us-central1
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,6 +1,9 @@
 import { createBackend } from '@backstage/backend-defaults';
 import { authModuleGithubProvider } from './plugins/auth'
-import { catalogModuleGoogleSQLDatabaseEntityProvider } from '@backtostage/plugin-catalog-backend-module-gcp';
+import {
+  catalogModuleGoogleSQLDatabaseEntityProvider,
+  catalogModuleGoogleRedisDatabaseEntityProvider
+} from '@backtostage/plugin-catalog-backend-module-gcp';
 
 const backend = createBackend();
 backend.add(import('@backstage/plugin-app-backend/alpha'));
@@ -20,6 +23,7 @@ backend.add(
   import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
 );
 backend.add(catalogModuleGoogleSQLDatabaseEntityProvider)
+backend.add(catalogModuleGoogleRedisDatabaseEntityProvider)
 
 
 // permission plugin

--- a/plugins/catalog-backend-module-gcp/README.md
+++ b/plugins/catalog-backend-module-gcp/README.md
@@ -27,6 +27,19 @@ backend.add(
 );
 ```
 
+### Memorystore Redis - GoogleRedisDatabaseEntityProvider
+
+To your new backend file, add:
+
+```ts title="packages/backend/src/index.ts"
+import { catalogModuleGoogleRedisDatabaseEntityProvider } from '@backtostage/plugin-catalog-backend-module-gcp';
+
+
+backend.add(
+  catalogModuleGoogleRedisDatabaseEntityProvider,
+);
+```
+
 ## Configuration
 
 To use this provider, you'll need a [Google Service Account](https://cloud.google.com/iam/docs/service-account-overview).
@@ -47,7 +60,10 @@ catalog:
         componentLabel: app # string
         cloudsql:
           resourceType: SQL  # string
-        schedule: same options as in TaskScheduleDefinition
+        redis:
+          resourceType: Redis  # string
+          location: us-central1 # string
+        schedule: # same options as in TaskScheduleDefinition
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 30 }
           # supports ISO duration, "human duration" as used in code
@@ -70,6 +86,13 @@ This provider supports multiple projects using different configurations.
     - **`resourceType`** _(optional)_:
       - Default: `CloudSQL`.
       - The provider will set the [`type`](https://backstage.io/docs/features/software-catalog/descriptor-format#spectype-required-4) based in this information.
+- **`redis`** _(optional)_:
+    - **`resourceType`** _(optional)_:
+      - Default: `Memorystore Redis`.
+      - The provider will set the [`type`](https://backstage.io/docs/features/software-catalog/descriptor-format#spectype-required-4) based in this information.
+    - **`location`** _(optional)_:
+      - Default: `` Wildcard value to [Google API](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1beta1/projects.locations.instances/list)
+      - You can narrow the location to list. When not provided instances from all locations will be listed
 - **`schedule`** _(required)_:
     - **`frequency`**:
       How often you want the task to run. The system does its best to avoid overlapping invocations.

--- a/plugins/catalog-backend-module-gcp/config.d.ts
+++ b/plugins/catalog-backend-module-gcp/config.d.ts
@@ -4,11 +4,6 @@ import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
 export interface Config {
   catalog?: {
     providers?: {
-      /**
-       * GithubEntityProvider configuration
-       *
-       * Uses "default" as default id for the single config variant.
-       */
       gcp?:
       Array<{
         project: string;
@@ -29,10 +24,23 @@ export interface Config {
            * Default: `CloudSQL`.
            */
           resourceType?: string;
+        },
+        
+        redis?: {
+          /**
+           * (Optional) The provider will set the Resource type based in this information.
+           * Default: `Memorystore Redis`.
+           */
+          resourceType?: string;
+          /**
+           * (Optional) The provider will use this location to retrieve instances.
+           * Default: `Wildcard for all locations`.
+           */
+          location?: string;
         }
 
         /**
-         * (Optional) TaskScheduleDefinition for the refresh.
+         * (Required) TaskScheduleDefinition for the refresh.
          */
         schedule?: TaskScheduleDefinitionConfig;
       }

--- a/plugins/catalog-backend-module-gcp/src/index.ts
+++ b/plugins/catalog-backend-module-gcp/src/index.ts
@@ -1,2 +1,5 @@
-export {GoogleSQLDatabaseEntityProvider} from "./providers/GoogleSQLDatabaseEntityProvider";
-export {catalogModuleGoogleSQLDatabaseEntityProvider} from './module'
+export { GoogleSQLDatabaseEntityProvider } from "./providers/GoogleSQLDatabaseEntityProvider";
+export {
+    catalogModuleGoogleSQLDatabaseEntityProvider,
+    catalogModuleGoogleRedisDatabaseEntityProvider
+} from './module'

--- a/plugins/catalog-backend-module-gcp/src/lib/redis.ts
+++ b/plugins/catalog-backend-module-gcp/src/lib/redis.ts
@@ -1,0 +1,37 @@
+import {google, redis_v1beta1} from "googleapis";
+
+const redisApi = google.redis('v1beta1');
+
+export async function listRedisInstances(project: string, location?: string) {
+
+    const client = await google.auth.getClient({
+        scopes: [
+            'https://www.googleapis.com/auth/cloud-platform',
+        ]
+    })
+    
+    // when location is not provided, we use `-` for wildcard
+    // ref https://cloud.google.com/memorystore/docs/redis/reference/rest/v1beta1/projects.locations.instances/list
+    const parent = `projects/${project}/locations/${location?? '-'}`
+
+    const request: redis_v1beta1.Params$Resource$Projects$Locations$Instances$List = {
+        parent,
+        auth: client,
+    };
+
+    const dbs: redis_v1beta1.Schema$Instance[] = []
+    do {
+        const response = await redisApi.projects.locations.instances.list(request);
+        if (!response) return []
+        const result = response.data
+
+        const itemsPage = result.instances;
+        if (!itemsPage) {
+            return [];
+        }
+        dbs.push(...itemsPage)
+        request.pageToken = result.nextPageToken ?? undefined;
+    } while (request.pageToken)
+
+    return dbs;
+}

--- a/plugins/catalog-backend-module-gcp/src/module/catalogModuleGoogleRedisDatabaseEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/module/catalogModuleGoogleRedisDatabaseEntityProvider.ts
@@ -1,0 +1,30 @@
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { GoogleRedisDatabaseEntityProvider } from '../providers/GoogleRedisDatabaseEntityProvider'
+
+export const catalogModuleGoogleRedisDatabaseEntityProvider = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'google-redis-database-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        config: coreServices.rootConfig,
+        catalog: catalogProcessingExtensionPoint,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
+      },
+      async init({ config, catalog, logger, scheduler }) {
+        catalog.addEntityProvider(
+          GoogleRedisDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            scheduler
+          })
+        );
+      },
+    });
+  },
+});

--- a/plugins/catalog-backend-module-gcp/src/module/index.ts
+++ b/plugins/catalog-backend-module-gcp/src/module/index.ts
@@ -1,1 +1,2 @@
 export { catalogModuleGoogleSQLDatabaseEntityProvider } from './catalogModuleGoogleSQLDatabaseEntityProvider';
+export { catalogModuleGoogleRedisDatabaseEntityProvider } from './catalogModuleGoogleRedisDatabaseEntityProvider';

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
@@ -1,0 +1,348 @@
+import { GoogleRedisDatabaseEntityProvider } from "./GoogleRedisDatabaseEntityProvider";
+import { TaskInvocationDefinition, TaskRunner, } from '@backstage/backend-tasks';
+import { ConfigReader } from '@backstage/config';
+import { getVoidLogger } from '@backstage/backend-common';
+import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
+import * as helpers from '../lib/redis';
+import { ANNOTATION_LOCATION, ANNOTATION_ORIGIN_LOCATION } from '@backstage/catalog-model';
+
+
+jest.mock('../lib/redis', () => {
+    return {
+        listRedisInstances: jest.fn(),
+    };
+});
+
+class PersistingTaskRunner implements TaskRunner {
+    private tasks: TaskInvocationDefinition[] = [];
+
+    getTasks() {
+        return this.tasks;
+    }
+
+    run(task: TaskInvocationDefinition): Promise<void> {
+        this.tasks.push(task);
+        return Promise.resolve(undefined);
+    }
+}
+
+const logger = getVoidLogger();
+describe('GoogleRedisDatabaseEntityProvider', () => {
+    afterEach(() => jest.resetAllMocks());
+
+    it('should be defined', () => {
+        expect(GoogleRedisDatabaseEntityProvider).toBeDefined()
+    })
+
+
+    it('no provider config', () => {
+        const scheduler =  {
+            createScheduledTaskRunner: jest.fn(),
+          } as any; 
+        const config = new ConfigReader({});
+        const providers = GoogleRedisDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            scheduler,
+        });
+
+        expect(providers).toHaveLength(0);
+    });
+
+    it('single simple provider config', () => {
+        const scheduler =  {
+            createScheduledTaskRunner: jest.fn(),
+          } as any; 
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: [{
+                        project: 'project',
+                        schedule: {
+                            frequency: { minutes: 30 },
+                            timeout: { minutes: 3 },
+                        }
+                    }],
+                },
+            },
+        });
+        const providers = GoogleRedisDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            scheduler,
+        });
+
+        expect(providers).toHaveLength(1);
+        expect(providers[0].getProviderName()).toEqual('google-redis-database-entity-provider:project-wildcard');
+    });
+
+    it('multiple provider configs', () => {
+        const scheduler =  {
+            createScheduledTaskRunner: jest.fn(),
+          } as any;          
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: [
+                        {
+                            project: 'myProvider',
+                            schedule: {
+                                frequency: { minutes: 30 },
+                                timeout: { minutes: 3 },
+                            }
+                        },
+                        {
+                            project: 'anotherProvider',
+                            schedule: {
+                                frequency: { minutes: 30 },
+                                timeout: { minutes: 3 },
+                            },
+                            redis: {
+                                location: "us-central1"
+                            }
+                        },
+                    ],
+                },
+            },
+        });
+        const providers = GoogleRedisDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            scheduler,
+        });
+
+        expect(providers).toHaveLength(2);
+        expect(providers[0].getProviderName()).toEqual(
+            'google-redis-database-entity-provider:myProvider-wildcard',
+        );
+        expect(providers[1].getProviderName()).toEqual(
+            'google-redis-database-entity-provider:anotherProvider-us-central1',
+        );
+    });
+
+    it('apply full update on scheduled execution with simple config', async () => {
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: [{
+                        project: 'myProvider',
+                        schedule: {
+                            frequency: { minutes: 30 },
+                            timeout: { minutes: 3 },
+                        }
+                    }],
+                },
+            },
+        });
+        const schedule = new PersistingTaskRunner()
+        const scheduler =  {
+            createScheduledTaskRunner: jest.fn(_ => schedule),
+          } as any;
+        
+        const entityProviderConnection: EntityProviderConnection = {
+            applyMutation: jest.fn(),
+            refresh: jest.fn(),
+        };
+
+        const provider = GoogleRedisDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            scheduler,
+        })[0];
+
+        const mockListRedisInstances = jest.spyOn(
+            helpers,
+            'listRedisInstances',
+        );
+
+        mockListRedisInstances.mockReturnValue(
+            Promise.resolve([
+                {
+                    name: "projects/myProvider/locations/us-central1/instances/database-name",                    
+                    labels: {
+                        owner: 'owner',
+                        component: 'my-service',
+                    }
+                },
+                {
+                    name: 'projects/myProvider/locations/us-central1/instances/another-database-name',
+                    labels: {
+                        owner: 'owner2',
+                        component: 'my-other-service',
+                    }
+                }
+            ]),
+        );
+
+        await provider.connect(entityProviderConnection);
+
+        const taskDef = schedule.getTasks()[0];
+        expect(taskDef.id).toEqual('google-redis-database-entity-provider:myProvider-wildcard:refresh');
+        await (taskDef.fn as () => Promise<void>)();
+
+        const expectedEntities = [
+            {
+                entity: {
+                    kind: 'Resource',
+                    apiVersion: 'backstage.io/v1alpha1',
+                    metadata: {
+                        annotations: {
+                            [ANNOTATION_LOCATION]: `google-redis-database-entity-provider:myProvider`,
+                            [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:myProvider`,
+                            "backtostage.app/google-project": "myProvider",
+                        },
+                        name: 'database-name',
+                        links: [
+                            {
+                                title: "Redis URL",
+                                url: "https://console.cloud.google.com/memorystore/redis/locations/us-central1/instances/database-name/details/overview?project=myProvider"
+                            }
+                        ],
+                    },
+                    spec: {
+                        dependencyOf: [
+                            'component:my-service'
+                        ],
+                        owner: 'owner',
+                        type: 'Memorystore Redis'
+                    }
+                },
+                locationKey: 'google-redis-database-entity-provider:myProvider-wildcard',
+            },
+            {
+                entity: {
+                    kind: 'Resource',
+                    apiVersion: 'backstage.io/v1alpha1',
+                    metadata: {
+                        annotations: {
+                            [ANNOTATION_LOCATION]: `google-redis-database-entity-provider:myProvider`,
+                            [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:myProvider`,
+                            "backtostage.app/google-project": "myProvider",
+                        },
+                        name: 'another-database-name',
+                        links: [
+                            {
+                                title: "Redis URL",
+                                url: "https://console.cloud.google.com/memorystore/redis/locations/us-central1/instances/another-database-name/details/overview?project=myProvider"
+                            }
+                        ],
+                    },
+                    spec: {
+                        dependencyOf: [
+                            'component:my-other-service'
+                        ],
+                        owner: 'owner2',
+                        type: 'Memorystore Redis'
+                    }
+                },
+                locationKey: 'google-redis-database-entity-provider:myProvider-wildcard',
+            }
+
+        ];
+
+        expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
+        expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+            type: 'full',
+            entities: expectedEntities,
+        });
+    });
+
+    it('skip resource when name not match the pattern', async () => {
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: [{
+                        project: 'myProvider',
+                        schedule: {
+                            frequency: { minutes: 30 },
+                            timeout: { minutes: 3 },
+                        }
+                    }],
+                },
+            },
+        });
+        const schedule = new PersistingTaskRunner()
+        const scheduler =  {
+            createScheduledTaskRunner: jest.fn(_ => schedule),
+          } as any;
+        
+        const entityProviderConnection: EntityProviderConnection = {
+            applyMutation: jest.fn(),
+            refresh: jest.fn(),
+        };
+
+        const provider = GoogleRedisDatabaseEntityProvider.fromConfig({
+            config,
+            logger,
+            scheduler,
+        })[0];
+
+        const mockListRedisInstances = jest.spyOn(
+            helpers,
+            'listRedisInstances',
+        );
+
+        mockListRedisInstances.mockReturnValue(
+            Promise.resolve([
+                {
+                    name: "STRANGER_NAME_FROM_GCP",                    
+                    labels: {
+                        owner: 'owner',
+                        component: 'my-service',
+                    }
+                },
+                {
+                    name: 'projects/myProvider/locations/us-central1/instances/another-database-name',
+                    labels: {
+                        owner: 'owner2',
+                        component: 'my-other-service',
+                    }
+                }
+            ]),
+        );
+
+        await provider.connect(entityProviderConnection);
+
+        const taskDef = schedule.getTasks()[0];
+        expect(taskDef.id).toEqual('google-redis-database-entity-provider:myProvider-wildcard:refresh');
+        await (taskDef.fn as () => Promise<void>)();
+
+        const expectedEntities = [
+            {
+                entity: {
+                    kind: 'Resource',
+                    apiVersion: 'backstage.io/v1alpha1',
+                    metadata: {
+                        annotations: {
+                            [ANNOTATION_LOCATION]: `google-redis-database-entity-provider:myProvider`,
+                            [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:myProvider`,
+                            "backtostage.app/google-project": "myProvider",
+                        },
+                        name: 'another-database-name',
+                        links: [
+                            {
+                                title: "Redis URL",
+                                url: "https://console.cloud.google.com/memorystore/redis/locations/us-central1/instances/another-database-name/details/overview?project=myProvider"
+                            }
+                        ],
+                    },
+                    spec: {
+                        dependencyOf: [
+                            'component:my-other-service'
+                        ],
+                        owner: 'owner2',
+                        type: 'Memorystore Redis'
+                    }
+                },
+                locationKey: 'google-redis-database-entity-provider:myProvider-wildcard',
+            }
+
+        ];
+
+        expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
+        expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+            type: 'full',
+            entities: expectedEntities,
+        });
+    });
+});

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.ts
@@ -1,0 +1,98 @@
+import { EntityProvider, EntityProviderConnection, } from '@backstage/plugin-catalog-node';
+import { Config } from "@backstage/config";
+import { GoogleRedisDatabaseEntityProviderConfig, readProviderConfigs } from "./GoogleRedisDatabaseEntityProviderConfig";
+import { GoogleDatabaseResourceTransformer } from "../transformers/defaultResourceTransformer";
+import { TaskRunner } from '@backstage/backend-tasks';
+import { LoggerService, SchedulerService } from '@backstage/backend-plugin-api';
+import * as uuid from "uuid";
+import { listRedisInstances } from "../lib/redis";
+import { ResourceEntityV1alpha1 } from '@backstage/catalog-model';
+
+
+export class GoogleRedisDatabaseEntityProvider implements EntityProvider {
+    private readonly logger: LoggerService;
+    private readonly scheduleFn: () => Promise<void>;
+    private connection?: EntityProviderConnection;
+
+    static fromConfig(options: {
+        config: Config,
+        resourceTransformer?: GoogleDatabaseResourceTransformer,
+        logger: LoggerService,
+        scheduler: SchedulerService;
+    }) {
+
+        return readProviderConfigs(options).map((providerConfig) => {
+            return new GoogleRedisDatabaseEntityProvider(
+                providerConfig,
+                options.scheduler.createScheduledTaskRunner(providerConfig.schedule),
+                options.logger
+            )
+        })
+    }
+
+    constructor(private config: GoogleRedisDatabaseEntityProviderConfig, taskRunner: TaskRunner, logger: LoggerService) {
+        this.scheduleFn = this.createScheduleFn(taskRunner);
+        this.logger = logger.child({
+            target: this.getProviderName(),
+        });
+    }
+
+    async connect(connection: EntityProviderConnection): Promise<void> {
+        this.connection = connection;
+        return await this.scheduleFn();
+    }
+
+
+    getProviderName(): string {
+        return `google-redis-database-entity-provider:${this.config.project}-${this.config.location?? 'wildcard'}`;
+    }
+
+    async refresh(logger: LoggerService) {
+        if (!this.connection) {
+            throw new Error('Not initialized');
+        }
+        logger.info(`Reading GCP Redis Instances for project ${this.config.project} in location ${this.config.location}`);
+        const databases = await listRedisInstances(this.config.project, this.config.location)
+        const resources: ResourceEntityV1alpha1[] = []
+        for (let index = 0; index < databases.length; index++) {
+            const db = databases[index];
+            try {
+                const result = this.config.resourceTransformer(this.config, db)
+                if(result) resources.push(result)
+            } catch (error) {
+                logger.error(`Error to transform ${db} - ${error}`)
+            }
+        }
+
+        await this.connection.applyMutation({
+            type: 'full',
+            entities: resources.map(entity => ({
+                entity,
+                locationKey: this.getProviderName(),
+            })),
+        });
+
+    }
+    private createScheduleFn(taskRunner: TaskRunner): () => Promise<void> {
+        return async () => {
+            const taskId = `${this.getProviderName()}:refresh`;
+            return taskRunner.run({
+                id: taskId,
+                fn: async () => {
+                    const logger = this.logger.child({
+                        class: GoogleRedisDatabaseEntityProvider.prototype.constructor.name,
+                        taskId,
+                        taskInstanceId: uuid.v4(),
+                    });
+                    try {
+                        await this.refresh(logger);
+                    } catch (error) {
+                        logger.error(`${this.getProviderName()} run failed ${error}`);
+                    }
+                },
+            });
+        };
+    }
+
+}
+

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.test.ts
@@ -1,0 +1,99 @@
+import { ConfigReader } from '@backstage/config';
+import { readProviderConfigs } from "./GoogleRedisDatabaseEntityProviderConfig";
+
+describe('readProviderConfigs', () => {
+    afterEach(() => jest.resetAllMocks());
+
+
+    it('no provider config', () => {
+        const config = new ConfigReader({});
+        const providerConfigs = readProviderConfigs({ config });
+
+        expect(providerConfigs).toHaveLength(0);
+    });
+
+    it('single simple provider config', () => {
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: [
+                        {
+                            project: 'my-project',
+                            schedule: {
+                                frequency: { minutes: 30 },
+                                timeout: { minutes: 3 },
+                            }
+                        },
+                    ],
+                },
+            },
+        });
+        const providerConfigs = readProviderConfigs({ config });
+
+        expect(providerConfigs).toHaveLength(1);
+        expect(providerConfigs[0].project).toEqual('my-project');
+        expect(providerConfigs[0].ownerLabel).toEqual('owner');
+        expect(providerConfigs[0].componentLabel).toEqual('component');
+        expect(providerConfigs[0].resourceType).toEqual('Memorystore Redis');
+        expect(providerConfigs[0].resourceTransformer).toBeDefined();
+        expect(providerConfigs[0].schedule).toBeDefined();
+
+    });
+
+    it('multiple provider configs', () => {
+        const config = new ConfigReader({
+            catalog: {
+                providers: {
+                    gcp: [
+                        {
+                            project: 'my-project',
+                            schedule: {
+                                frequency: { minutes: 10 },
+                                timeout: { minutes: 3 },
+                            }
+                        },
+                        {
+                            project: 'my-other-project',
+                            ownerLabel: 'team',
+                            componentLabel: 'app',
+                            redis: { resourceType: 'database', location: "us-central1" },
+                            schedule: {
+                                frequency: { minutes: 30 },
+                                timeout: { minutes: 3 },
+                            },
+                        },
+                    ],
+                }
+            },
+        });
+        const providerConfigs = readProviderConfigs({ config });
+
+        expect(providerConfigs).toHaveLength(2);
+        expect(providerConfigs[0]).toEqual({
+            project: 'my-project',
+            ownerLabel: 'owner',
+            componentLabel: 'component',
+            resourceType: 'Memorystore Redis',
+            resourceTransformer: expect.any(Function),
+            schedule: {
+                frequency: { minutes: 10 },
+                timeout: { minutes: 3 },
+            }
+        });
+
+        expect(providerConfigs[1]).toEqual({
+            project: 'my-other-project',
+            ownerLabel: 'team',
+            componentLabel: 'app',
+            resourceType: 'database',
+            resourceTransformer: expect.any(Function),
+            location: "us-central1",
+            schedule: {
+                frequency: { minutes: 30 },
+                timeout: { minutes: 3 },
+            },
+        });
+
+    });
+
+})

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.ts
@@ -1,0 +1,57 @@
+import { Config } from "@backstage/config";
+import {
+    defaultRedisResourceTransformer,
+    GoogleDatabaseResourceTransformer,
+    GoogleRedisResourceTransformer
+} from "../transformers/defaultResourceTransformer";
+import {
+    readTaskScheduleDefinitionFromConfig,
+    TaskScheduleDefinition,
+} from '@backstage/backend-tasks';
+
+export type GoogleRedisDatabaseEntityProviderConfig = {
+    project: string
+    location?: string
+    ownerLabel: string
+    componentLabel: string
+    resourceType: string
+    resourceTransformer: GoogleRedisResourceTransformer
+    schedule: TaskScheduleDefinition;
+}
+
+export function readProviderConfigs(options: {
+    config: Config,
+    resourceTransformer?: GoogleDatabaseResourceTransformer
+}): GoogleRedisDatabaseEntityProviderConfig[] {
+
+    const providersConfig = options.config.getOptionalConfigArray('catalog.providers.gcp');
+    if (!providersConfig) {
+        return [];
+    }
+
+    return providersConfig.map(config => readProviderConfig(config, options.resourceTransformer));
+}
+
+export function readProviderConfig(
+    config: Config,
+    resourceTransformer?: GoogleDatabaseResourceTransformer
+): GoogleRedisDatabaseEntityProviderConfig {
+    const project = config.getString("project");
+    const ownerLabel = config.getOptionalString('ownerLabel') ?? 'owner'
+    const componentLabel = config.getOptionalString('componentLabel') ?? 'component'
+    const resourceType = config.getOptionalString('redis.resourceType') ?? 'Memorystore Redis'
+    const location = config.getOptionalString('redis.location')
+
+
+    const schedule = readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'));
+
+    return {
+        project,
+        ownerLabel,
+        componentLabel,
+        resourceType,
+        location,
+        resourceTransformer: resourceTransformer ?? defaultRedisResourceTransformer,
+        schedule
+    }
+}


### PR DESCRIPTION
# Description
This change adds a new entity provider to import redis memorystore from GCP

We are using a separete module export to allow more flexibility in each resource you want to import in your backstage instance