### PR TITLE
add project locator to search projects in entity providers

### DIFF
--- a/.changeset/few-colts-pay.md
+++ b/.changeset/few-colts-pay.md
@@ -1,0 +1,7 @@
+---
+'@backtostage/plugin-catalog-backend-module-gcp': patch
+---
+
+Add locator to enable organization load
+
+You can now use [Google API](https://cloud.google.com/resource-manager/reference/rest/v3/projects/search#query-parameters) to load projects from your organization and that will be used to load GCP Resources.

--- a/plugins/catalog-backend-module-gcp/README.md
+++ b/plugins/catalog-backend-module-gcp/README.md
@@ -98,6 +98,7 @@ This provider supports multiple projects using different configurations.
 
 - **`project`** _(required when not using organization import)_:
   Project ID of the project for which to list Cloud SQL instances.
+  You can omit that field if you want the provider to load all projects in your organization to load other resources.
 - **`organization`** _(optional)_:
     - **`query`** _(optional)_:
       - Default: `` Query param to [Google API](https://cloud.google.com/resource-manager/reference/rest/v3/projects/search#query-parameters)

--- a/plugins/catalog-backend-module-gcp/src/project-locator/GoogleProjectLocatorByConfig.ts
+++ b/plugins/catalog-backend-module-gcp/src/project-locator/GoogleProjectLocatorByConfig.ts
@@ -1,0 +1,8 @@
+import { GoogleProjectLocator } from "./types";
+
+export class GoogleProjectLocatorByConfig implements GoogleProjectLocator {
+    constructor(private readonly project: string) {}
+    async getProjects() {
+        return [this.project];
+    }
+}

--- a/plugins/catalog-backend-module-gcp/src/project-locator/GoogleProjectLocatorByOrganization.ts
+++ b/plugins/catalog-backend-module-gcp/src/project-locator/GoogleProjectLocatorByOrganization.ts
@@ -1,0 +1,12 @@
+import { GoogleProjectLocator } from "./types";
+import { listProjects } from '../lib/resourcemanager';
+
+export class GoogleProjectLocatorByOrganization implements GoogleProjectLocator {
+    constructor(private readonly query?: string) {}
+    async getProjects() {
+        const projects = await listProjects(this.query);
+        return projects
+            .map(project => project.projectId )
+            .filter(project => !!project) as string[];
+    }
+}

--- a/plugins/catalog-backend-module-gcp/src/project-locator/index.ts
+++ b/plugins/catalog-backend-module-gcp/src/project-locator/index.ts
@@ -1,0 +1,18 @@
+import { Config } from '@backstage/config';
+import { GoogleProjectLocator } from './types';
+import { GoogleProjectLocatorByConfig } from './GoogleProjectLocatorByConfig';
+import { GoogleProjectLocatorByOrganization } from './GoogleProjectLocatorByOrganization';
+
+export type { GoogleProjectLocator } from './types';
+
+
+
+export function getProjectLocator(config: Config): GoogleProjectLocator {
+    const project = config.getOptionalString('project');
+    if (project) {
+        return new GoogleProjectLocatorByConfig(project)
+    } 
+        const query = config.getOptionalString("organization.query");
+        return new GoogleProjectLocatorByOrganization(query)
+    
+}

--- a/plugins/catalog-backend-module-gcp/src/project-locator/types.ts
+++ b/plugins/catalog-backend-module-gcp/src/project-locator/types.ts
@@ -1,0 +1,3 @@
+export type GoogleProjectLocator = {
+    getProjects(): Promise<string[]>;
+}

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.ts
@@ -71,7 +71,7 @@ export class GoogleRedisDatabaseEntityProvider implements EntityProvider {
                     logger.error(`Error to transform ${db} - ${error}`)
                 }
             }
-            
+            allResources.push(...resources); 
         }
 
         await this.connection.applyMutation({

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.test.ts
@@ -63,7 +63,7 @@ describe('readProviderConfigs', () => {
         const providerConfigs = readProviderConfigs({ config });
 
         expect(providerConfigs).toHaveLength(1);
-        expect(providerConfigs[0].project).toEqual('my-project');
+        expect(providerConfigs[0].id).toEqual('my-project');
         expect(providerConfigs[0].ownerLabel).toEqual('owner');
         expect(providerConfigs[0].componentLabel).toEqual('component');
         expect(providerConfigs[0].resourceType).toEqual('Memorystore Redis');
@@ -102,7 +102,10 @@ describe('readProviderConfigs', () => {
 
         expect(providerConfigs).toHaveLength(2);
         expect(providerConfigs[0]).toEqual({
-            project: 'my-project',
+            id: 'my-project',
+            projectLocator: {
+                project: 'my-project',
+            },
             ownerLabel: 'owner',
             componentLabel: 'component',
             resourceType: 'Memorystore Redis',
@@ -115,7 +118,10 @@ describe('readProviderConfigs', () => {
         });
 
         expect(providerConfigs[1]).toEqual({
-            project: 'my-other-project',
+            id: 'my-other-project',
+            projectLocator: {
+                project: 'my-other-project',
+            },
             ownerLabel: 'team',
             componentLabel: 'app',
             resourceType: 'database',

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.ts
@@ -7,9 +7,11 @@ import {
     readTaskScheduleDefinitionFromConfig,
     TaskScheduleDefinition,
 } from '@backstage/backend-tasks';
+import { getProjectLocator, GoogleProjectLocator } from "../project-locator";
 
 export type GoogleRedisDatabaseEntityProviderConfig = {
-    project: string
+    id: string
+    projectLocator: GoogleProjectLocator
     location?: string
     ownerLabel: string
     componentLabel: string
@@ -38,7 +40,8 @@ export function readProviderConfig(
     config: Config,
     resourceTransformer?: GoogleRedisResourceTransformer
 ): GoogleRedisDatabaseEntityProviderConfig {
-    const project = config.getString("project");
+    // when project is not defined, default to 'organization'
+    const id = config.getOptionalString("project") ?? 'organization';
     const ownerLabel = config.getOptionalString('ownerLabel') ?? 'owner'
     const componentLabel = config.getOptionalString('componentLabel') ?? 'component'
     const resourceType = config.getOptionalString('redis.resourceType') ?? 'Memorystore Redis'
@@ -49,11 +52,12 @@ export function readProviderConfig(
     const schedule = readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'));
 
     return {
-        project,
+        id,
         ownerLabel,
         componentLabel,
         resourceType,
         location,
+        projectLocator: getProjectLocator(config),
         resourceTransformer: resourceTransformer ?? defaultRedisResourceTransformer,
         schedule,
         disabled

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.test.ts
@@ -65,7 +65,7 @@ describe('readProviderConfigs', () => {
         const providerConfigs = readProviderConfigs({ config });
 
         expect(providerConfigs).toHaveLength(1);
-        expect(providerConfigs[0].project).toEqual('my-project');
+        expect(providerConfigs[0].id).toEqual('my-project');
         expect(providerConfigs[0].ownerLabel).toEqual('owner');
         expect(providerConfigs[0].componentLabel).toEqual('component');
         expect(providerConfigs[0].resourceType).toEqual('CloudSQL');
@@ -96,15 +96,31 @@ describe('readProviderConfigs', () => {
                                 timeout: { minutes: 3 },
                             },
                         },
+                        {
+                            organization: {
+                                query: 'parent:organizations/my-org'
+                            },
+                            ownerLabel: 'team',
+                            componentLabel: 'app',
+                            cloudsql: { resourceType: 'SQL', },
+                            schedule: {
+                                frequency: { minutes: 30 },
+                                timeout: { minutes: 3 },
+                            },
+                        },
                     ],
                 }
             },
         });
         const providerConfigs = readProviderConfigs({ config });
 
-        expect(providerConfigs).toHaveLength(2);
+        expect(providerConfigs).toHaveLength(3);
+
         expect(providerConfigs[0]).toEqual({
-            project: 'my-project',
+            id: 'my-project',
+            projectLocator: {
+                project: 'my-project',
+            },
             ownerLabel: 'owner',
             componentLabel: 'component',
             resourceType: 'CloudSQL',
@@ -117,7 +133,26 @@ describe('readProviderConfigs', () => {
         });
 
         expect(providerConfigs[1]).toEqual({
-            project: 'my-other-project',
+            id: 'my-other-project',
+            projectLocator: {
+                project: 'my-other-project',
+            },
+            ownerLabel: 'team',
+            componentLabel: 'app',
+            resourceType: 'SQL',
+            resourceTransformer: expect.any(Function),
+            schedule: {
+                frequency: { minutes: 30 },
+                timeout: { minutes: 3 },
+            },
+            disabled: false,
+        });
+
+        expect(providerConfigs[2]).toEqual({
+            id: 'organization',
+            projectLocator: {
+                query: 'parent:organizations/my-org'
+            },
             ownerLabel: 'team',
             componentLabel: 'app',
             resourceType: 'SQL',

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.ts
@@ -7,9 +7,11 @@ import {
     readTaskScheduleDefinitionFromConfig,
     TaskScheduleDefinition,
 } from '@backstage/backend-tasks';
+import { getProjectLocator, GoogleProjectLocator } from "../project-locator";
 
 export type GoogleSQLDatabaseEntityProviderConfig = {
-    project: string
+    id: string
+    projectLocator: GoogleProjectLocator
     ownerLabel: string
     componentLabel: string
     resourceType: string
@@ -17,6 +19,7 @@ export type GoogleSQLDatabaseEntityProviderConfig = {
     schedule: TaskScheduleDefinition;
     disabled: boolean;
 }
+
 
 export function readProviderConfigs(options: {
     config: Config,
@@ -37,7 +40,8 @@ export function readProviderConfig(
     config: Config,
     resourceTransformer?: GoogleDatabaseResourceTransformer
 ): GoogleSQLDatabaseEntityProviderConfig {
-    const project = config.getString("project");
+    // when project is not defined, default to 'organization'
+    const id = config.getOptionalString("project") ?? 'organization';
     const ownerLabel = config.getOptionalString('ownerLabel') ?? 'owner'
     const componentLabel = config.getOptionalString('componentLabel') ?? 'component'
     const resourceType = config.getOptionalString('cloudsql.resourceType') ?? 'CloudSQL'
@@ -46,7 +50,8 @@ export function readProviderConfig(
     const schedule = readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'));
 
     return {
-        project,
+        id,
+        projectLocator: getProjectLocator(config),
         ownerLabel,
         componentLabel,
         resourceType,
@@ -55,3 +60,4 @@ export function readProviderConfig(
         disabled
     }
 }
+

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
@@ -2,6 +2,7 @@ import {defaultDatabaseResourceTransformer} from "./defaultResourceTransformer";
 import {GoogleSQLDatabaseEntityProviderConfig} from "../providers/GoogleSQLDatabaseEntityProviderConfig";
 import {sqladmin_v1beta4} from "googleapis";
 import {ANNOTATION_LOCATION, ANNOTATION_ORIGIN_LOCATION} from "@backstage/catalog-model";
+import { GoogleProjectLocatorByConfig } from "../project-locator/GoogleProjectLocatorByConfig";
 
 describe('defaultDatabaseResourceTransformer', () => {
     it('should be defined', () => {
@@ -10,7 +11,8 @@ describe('defaultDatabaseResourceTransformer', () => {
 
     describe('when a Database instance is provided', () => {
         const config: GoogleSQLDatabaseEntityProviderConfig = {
-            project: 'project',
+            id: 'project',
+            projectLocator: new GoogleProjectLocatorByConfig("project"),
             componentLabel: 'component',
             ownerLabel: 'owner',
             resourceType: 'SQL',
@@ -26,7 +28,7 @@ describe('defaultDatabaseResourceTransformer', () => {
             name: 'database-name',
             databaseVersion: "POSTGRES_15",
             databaseInstalledVersion: "POSTGRES_15_7",
-            project: config.project,
+            project: "project",
             settings: {
                 userLabels: {
                     [config.ownerLabel]: 'owner',
@@ -43,16 +45,16 @@ describe('defaultDatabaseResourceTransformer', () => {
                 apiVersion: 'backstage.io/v1alpha1',
                 metadata: {
                     annotations: {
-                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
-                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
-                        "backtostage.app/google-project": config.project,
+                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
+                        "backtostage.app/google-project": config.id,
                         "backtostage.app/google-sql-database-version": "POSTGRES_15",
                         "backtostage.app/google-sql-database-installed-version": "POSTGRES_15_7",
                     },
                     name: 'database-name',
                     title: "database-name",
                     links: [{
-                        url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.project}`,
+                        url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.id}`,
                         title: "Database URL"
                     }]
                 },
@@ -68,7 +70,8 @@ describe('defaultDatabaseResourceTransformer', () => {
 
         it('should use unknown in a resource entity without label owner defined in database label', () => {
             const localConfig: GoogleSQLDatabaseEntityProviderConfig = {
-                project: 'project',
+                id: 'project',
+                projectLocator: new GoogleProjectLocatorByConfig("project"),
                 componentLabel: 'component',
                 ownerLabel: 'ownerNotPresent',
                 resourceType: 'SQL',
@@ -86,16 +89,16 @@ describe('defaultDatabaseResourceTransformer', () => {
                 apiVersion: 'backstage.io/v1alpha1',
                 metadata: {
                     annotations: {
-                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
-                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
-                        "backtostage.app/google-project": config.project,
+                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
+                        "backtostage.app/google-project": config.id,
                         "backtostage.app/google-sql-database-version": "POSTGRES_15",
                         "backtostage.app/google-sql-database-installed-version": "POSTGRES_15_7",
                     },
                     name: 'database-name',
                     title: "database-name",
                     links: [{
-                        url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.project}`,
+                        url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.id}`,
                         title: "Database URL"
                     }]
                 },
@@ -111,7 +114,8 @@ describe('defaultDatabaseResourceTransformer', () => {
 
         it('should use empty dependencies in a resource entity without label component defined in database label', () => {
             const localConfig: GoogleSQLDatabaseEntityProviderConfig = {
-                project: 'project',
+                id: 'project',
+                projectLocator: new GoogleProjectLocatorByConfig("project"),
                 componentLabel: 'componentNotPresent',
                 ownerLabel: 'owner',
                 resourceType: 'SQL',
@@ -129,16 +133,16 @@ describe('defaultDatabaseResourceTransformer', () => {
                 apiVersion: 'backstage.io/v1alpha1',
                 metadata: {
                     annotations: {
-                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
-                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
-                        "backtostage.app/google-project": config.project,
+                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
+                        "backtostage.app/google-project": config.id,
                         "backtostage.app/google-sql-database-version": "POSTGRES_15",
                         "backtostage.app/google-sql-database-installed-version": "POSTGRES_15_7",
                     },
                     name: 'database-name',
                     title: "database-name",
                     links: [{
-                        url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.project}`,
+                        url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.id}`,
                         title: "Database URL"
                     }]
                 },
@@ -160,8 +164,8 @@ describe('defaultDatabaseResourceTransformer', () => {
                 apiVersion: 'backstage.io/v1alpha1',
                 metadata: {
                     annotations: {
-                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
-                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.project}`,
+                        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
+                        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
                         
                     },
                     name: 'database-name',

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
@@ -17,8 +17,8 @@ const PROJECT_NAME_PARSE =/projects(?<project>.*)\/(?<name>.*)/
 export type GoogleDatabaseResourceTransformer = (providerConfig: GoogleSQLDatabaseEntityProviderConfig, database: sqladmin_v1beta4.Schema$DatabaseInstance) => ResourceEntity
 export const defaultDatabaseResourceTransformer: GoogleDatabaseResourceTransformer = (providerConfig: GoogleSQLDatabaseEntityProviderConfig, database: sqladmin_v1beta4.Schema$DatabaseInstance): ResourceEntity => {
     const annotations: { [name: string]: string } = {
-        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${providerConfig.project}`,
-        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${providerConfig.project}`,
+        [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:${providerConfig.id}`,
+        [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${providerConfig.id}`,
     };
 
     if (database.project) annotations[ANNOTATION_GCP_PROJECT] = database.project
@@ -63,8 +63,8 @@ export const defaultDatabaseResourceTransformer: GoogleDatabaseResourceTransform
 export type GoogleRedisResourceTransformer = (providerConfig: GoogleRedisDatabaseEntityProviderConfig, redis: redis_v1beta1.Schema$Instance) => ResourceEntity
 export const defaultRedisResourceTransformer: GoogleRedisResourceTransformer = (providerConfig: GoogleRedisDatabaseEntityProviderConfig, redis: redis_v1beta1.Schema$Instance): ResourceEntity => {
     const annotations: { [name: string]: string } = {
-        [ANNOTATION_LOCATION]: `google-redis-database-entity-provider:${providerConfig.project}`,
-        [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:${providerConfig.project}`,
+        [ANNOTATION_LOCATION]: `google-redis-database-entity-provider:${providerConfig.id}`,
+        [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:${providerConfig.id}`,
     };
     
     const redisNameGroup = REDIS_NAME_PARSE.exec(redis.name?? "")?.groups


### PR DESCRIPTION
# Description
Add locator to enable organization load

You can now use [Google API](https://cloud.google.com/resource-manager/reference/rest/v3/projects/search#query-parameters) to load projects from your organization and that will be used to load GCP Resources.