### PR TITLE
Add suffix option

### DIFF
--- a/.changeset/few-pigs-brush.md
+++ b/.changeset/few-pigs-brush.md
@@ -1,0 +1,5 @@
+---
+'@backtostage/plugin-catalog-backend-module-gcp': patch
+---
+
+Add a suffix option to import resources and avoid name clash. To avoid errors in the config, default values are provided.

--- a/plugins/catalog-backend-module-gcp/README.md
+++ b/plugins/catalog-backend-module-gcp/README.md
@@ -73,10 +73,12 @@ catalog:
         componentLabel: app # string
         cloudsql:
           resourceType: SQL  # string
+          suffix: sql  # string
           disabled: true # boolean
         redis:
           resourceType: Redis  # string
           location: us-central1 # string
+          suffix: memorystoreredis  # string
           disabled: true # boolean
         schedule: # same options as in TaskScheduleDefinition
           # supports cron, ISO duration, "human duration" as used in code
@@ -124,6 +126,9 @@ This provider supports multiple projects using different configurations.
     - **`resourceType`** _(optional)_:
       - Default: `CloudSQL`.
       - The provider will set the [`type`](https://backstage.io/docs/features/software-catalog/descriptor-format#spectype-required-4) based in this information.
+    - **`suffix`** _(optional)_:
+      - Default: `cloudsql`.
+      - The provider will set the suffix to create a unique name for this resource.
     - **`disabled`** _(optional)_:
       - Default: `false`.
       - The entity provider will skip this configuration when disabled.
@@ -132,6 +137,9 @@ This provider supports multiple projects using different configurations.
     - **`resourceType`** _(optional)_:
       - Default: `Memorystore Redis`.
       - The provider will set the [`type`](https://backstage.io/docs/features/software-catalog/descriptor-format#spectype-required-4) based in this information.
+    - **`suffix`** _(optional)_:
+      - Default: `redis`.
+      - The provider will set the suffix to create a unique name for this resource.
     - **`location`** _(optional)_:
       - Default: `` Wildcard value to [Google API](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1beta1/projects.locations.instances/list)
       - You can narrow the location to list. When not provided instances from all locations will be listed

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
@@ -191,7 +191,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                             [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:myProvider`,
                             "backtostage.app/google-project": "myProvider",
                         },
-                        name: 'database-name',
+                        name: 'database-name-redis',
                         links: [
                             {
                                 title: "Redis URL",
@@ -219,7 +219,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                             [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:myProvider`,
                             "backtostage.app/google-project": "myProvider",
                         },
-                        name: 'another-database-name',
+                        name: 'another-database-name-redis',
                         links: [
                             {
                                 title: "Redis URL",
@@ -318,7 +318,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                             [ANNOTATION_ORIGIN_LOCATION]: `google-redis-database-entity-provider:myProvider`,
                             "backtostage.app/google-project": "myProvider",
                         },
-                        name: 'another-database-name',
+                        name: 'another-database-name-redis',
                         links: [
                             {
                                 title: "Redis URL",

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.test.ts
@@ -67,6 +67,7 @@ describe('readProviderConfigs', () => {
         expect(providerConfigs[0].ownerLabel).toEqual('owner');
         expect(providerConfigs[0].componentLabel).toEqual('component');
         expect(providerConfigs[0].resourceType).toEqual('Memorystore Redis');
+        expect(providerConfigs[0].suffix).toEqual('redis');
         expect(providerConfigs[0].resourceTransformer).toBeDefined();
         expect(providerConfigs[0].schedule).toBeDefined();
 
@@ -88,7 +89,7 @@ describe('readProviderConfigs', () => {
                             project: 'my-other-project',
                             ownerLabel: 'team',
                             componentLabel: 'app',
-                            redis: { resourceType: 'database', location: "us-central1" },
+                            redis: { resourceType: 'database', location: "us-central1", suffix: "database" },
                             schedule: {
                                 frequency: { minutes: 30 },
                                 timeout: { minutes: 3 },
@@ -109,6 +110,7 @@ describe('readProviderConfigs', () => {
             ownerLabel: 'owner',
             componentLabel: 'component',
             resourceType: 'Memorystore Redis',
+            suffix: "redis",
             resourceTransformer: expect.any(Function),
             schedule: {
                 frequency: { minutes: 10 },
@@ -125,6 +127,7 @@ describe('readProviderConfigs', () => {
             ownerLabel: 'team',
             componentLabel: 'app',
             resourceType: 'database',
+            suffix: "database",
             resourceTransformer: expect.any(Function),
             location: "us-central1",
             schedule: {

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProviderConfig.ts
@@ -16,6 +16,7 @@ export type GoogleRedisDatabaseEntityProviderConfig = {
     ownerLabel: string
     componentLabel: string
     resourceType: string
+    suffix: string
     resourceTransformer: GoogleRedisResourceTransformer
     schedule: TaskScheduleDefinition;
     disabled: boolean;
@@ -45,6 +46,7 @@ export function readProviderConfig(
     const ownerLabel = config.getOptionalString('ownerLabel') ?? 'owner'
     const componentLabel = config.getOptionalString('componentLabel') ?? 'component'
     const resourceType = config.getOptionalString('redis.resourceType') ?? 'Memorystore Redis'
+    const suffix = config.getOptionalString('redis.suffix') ?? 'redis'
     const location = config.getOptionalString('redis.location')
 
     const disabled = config.getOptionalBoolean('redis.disabled') || false;
@@ -56,6 +58,7 @@ export function readProviderConfig(
         ownerLabel,
         componentLabel,
         resourceType,
+        suffix,
         location,
         projectLocator: getProjectLocator(config),
         resourceTransformer: resourceTransformer ?? defaultRedisResourceTransformer,

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
@@ -191,8 +191,8 @@ describe('GoogleSQLDatabaseEntityProvider', () => {
                             [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:myProvider`,
                             [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:myProvider`,
                         },
-                        name: 'database-name',
-                        title: "database-name",
+                        name: 'database-name-cloudsql',
+                        title: "database-name-cloudsql",
                         links: [],
                     },
                     spec: {
@@ -214,8 +214,8 @@ describe('GoogleSQLDatabaseEntityProvider', () => {
                             [ANNOTATION_LOCATION]: `google-sql-database-entity-provider:myProvider`,
                             [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:myProvider`,
                         },
-                        name: 'another-database-name',
-                        title: "another-database-name",
+                        name: 'another-database-name-cloudsql',
+                        title: "another-database-name-cloudsql",
                         links: [],
                     },
                     spec: {

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.test.ts
@@ -69,6 +69,7 @@ describe('readProviderConfigs', () => {
         expect(providerConfigs[0].ownerLabel).toEqual('owner');
         expect(providerConfigs[0].componentLabel).toEqual('component');
         expect(providerConfigs[0].resourceType).toEqual('CloudSQL');
+        expect(providerConfigs[0].suffix).toEqual('cloudsql');
         expect(providerConfigs[0].resourceTransformer).toBeDefined();
         expect(providerConfigs[0].schedule).toBeDefined();
 
@@ -102,7 +103,7 @@ describe('readProviderConfigs', () => {
                             },
                             ownerLabel: 'team',
                             componentLabel: 'app',
-                            cloudsql: { resourceType: 'SQL', },
+                            cloudsql: { resourceType: 'SQL', suffix: "sql", },
                             schedule: {
                                 frequency: { minutes: 30 },
                                 timeout: { minutes: 3 },
@@ -124,6 +125,7 @@ describe('readProviderConfigs', () => {
             ownerLabel: 'owner',
             componentLabel: 'component',
             resourceType: 'CloudSQL',
+            suffix: "cloudsql",
             resourceTransformer: expect.any(Function),
             schedule: {
                 frequency: { minutes: 10 },
@@ -140,6 +142,7 @@ describe('readProviderConfigs', () => {
             ownerLabel: 'team',
             componentLabel: 'app',
             resourceType: 'SQL',
+            suffix: "cloudsql",
             resourceTransformer: expect.any(Function),
             schedule: {
                 frequency: { minutes: 30 },
@@ -156,6 +159,7 @@ describe('readProviderConfigs', () => {
             ownerLabel: 'team',
             componentLabel: 'app',
             resourceType: 'SQL',
+            suffix: "sql",
             resourceTransformer: expect.any(Function),
             schedule: {
                 frequency: { minutes: 30 },

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProviderConfig.ts
@@ -15,6 +15,7 @@ export type GoogleSQLDatabaseEntityProviderConfig = {
     ownerLabel: string
     componentLabel: string
     resourceType: string
+    suffix: string
     resourceTransformer: GoogleDatabaseResourceTransformer
     schedule: TaskScheduleDefinition;
     disabled: boolean;
@@ -45,6 +46,7 @@ export function readProviderConfig(
     const ownerLabel = config.getOptionalString('ownerLabel') ?? 'owner'
     const componentLabel = config.getOptionalString('componentLabel') ?? 'component'
     const resourceType = config.getOptionalString('cloudsql.resourceType') ?? 'CloudSQL'
+    const suffix = config.getOptionalString('cloudsql.suffix') ?? 'cloudsql'
     const disabled = config.getOptionalBoolean('cloudsql.disabled') || false;
 
     const schedule = readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'));
@@ -55,6 +57,7 @@ export function readProviderConfig(
         ownerLabel,
         componentLabel,
         resourceType,
+        suffix,
         resourceTransformer: resourceTransformer ?? defaultDatabaseResourceTransformer,
         schedule,
         disabled

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
@@ -16,6 +16,7 @@ describe('defaultDatabaseResourceTransformer', () => {
             componentLabel: 'component',
             ownerLabel: 'owner',
             resourceType: 'SQL',
+            suffix: "sql",
             resourceTransformer: defaultDatabaseResourceTransformer,
             schedule: {
                 frequency: { minutes: 30 },
@@ -51,8 +52,8 @@ describe('defaultDatabaseResourceTransformer', () => {
                         "backtostage.app/google-sql-database-version": "POSTGRES_15",
                         "backtostage.app/google-sql-database-installed-version": "POSTGRES_15_7",
                     },
-                    name: 'database-name',
-                    title: "database-name",
+                    name: 'database-name-sql',
+                    title: "database-name-sql",
                     links: [{
                         url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.id}`,
                         title: "Database URL"
@@ -75,6 +76,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 componentLabel: 'component',
                 ownerLabel: 'ownerNotPresent',
                 resourceType: 'SQL',
+                suffix: "sql",
                 resourceTransformer: defaultDatabaseResourceTransformer,
                 schedule: {
                     frequency: { minutes: 30 },
@@ -95,8 +97,8 @@ describe('defaultDatabaseResourceTransformer', () => {
                         "backtostage.app/google-sql-database-version": "POSTGRES_15",
                         "backtostage.app/google-sql-database-installed-version": "POSTGRES_15_7",
                     },
-                    name: 'database-name',
-                    title: "database-name",
+                    name: 'database-name-sql',
+                    title: "database-name-sql",
                     links: [{
                         url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.id}`,
                         title: "Database URL"
@@ -119,6 +121,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 componentLabel: 'componentNotPresent',
                 ownerLabel: 'owner',
                 resourceType: 'SQL',
+                suffix: "sql",
                 resourceTransformer: defaultDatabaseResourceTransformer,
                 schedule: {
                     frequency: { minutes: 30 },
@@ -139,8 +142,8 @@ describe('defaultDatabaseResourceTransformer', () => {
                         "backtostage.app/google-sql-database-version": "POSTGRES_15",
                         "backtostage.app/google-sql-database-installed-version": "POSTGRES_15_7",
                     },
-                    name: 'database-name',
-                    title: "database-name",
+                    name: 'database-name-sql',
+                    title: "database-name-sql",
                     links: [{
                         url : `https://console.cloud.google.com/sql/instances/database-name/overview?project=${config.id}`,
                         title: "Database URL"
@@ -168,8 +171,8 @@ describe('defaultDatabaseResourceTransformer', () => {
                         [ANNOTATION_ORIGIN_LOCATION]: `google-sql-database-entity-provider:${config.id}`,
                         
                     },
-                    name: 'database-name',
-                    title: "database-name",
+                    name: 'database-name-sql',
+                    title: "database-name-sql",
                     links: [],
                 },
                 spec: {

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
@@ -92,7 +92,7 @@ export const defaultRedisResourceTransformer: GoogleRedisResourceTransformer = (
         apiVersion: 'backstage.io/v1alpha1',
         metadata: {
             annotations,
-            name: redisNameGroup.name,
+            name: `${redisNameGroup.name}-${providerConfig.suffix}`,
             links,
         },
         spec: {

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
@@ -40,8 +40,8 @@ export const defaultDatabaseResourceTransformer: GoogleDatabaseResourceTransform
         apiVersion: 'backstage.io/v1alpha1',
         metadata: {
             annotations,
-            name: database.name!,
-            title: database.name!,
+            name: `${database.name!}-${providerConfig.suffix}`,
+            title: `${database.name!}-${providerConfig.suffix}`,
             links,
         },
         spec: {


### PR DESCRIPTION
# Description
This PR provides a `suffix` option to avoid problems like the clash in #204 

Now the resources will receive a suffix based in config. The suffix was choosed over the prefix to avoid noise on the search. The name starts like the resource name you expect, just the end is changing