### PR TITLE
fix: update owner namespace to be always DEFAULT_NAMESPACE fix #219

### DIFF
--- a/.changeset/smart-nails-sin.md
+++ b/.changeset/smart-nails-sin.md
@@ -1,0 +1,5 @@
+---
+'@backtostage/plugin-catalog-backend-module-gcp': patch
+---
+
+fix unexpected owner namespace behavior on use namespaceByProject

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
@@ -203,7 +203,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                         dependencyOf: [
                             'component:my-service'
                         ],
-                        owner: 'owner',
+                        owner: 'default/owner',
                         type: 'Memorystore Redis'
                     }
                 },
@@ -231,7 +231,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                         dependencyOf: [
                             'component:my-other-service'
                         ],
-                        owner: 'owner2',
+                        owner: 'default/owner2',
                         type: 'Memorystore Redis'
                     }
                 },
@@ -330,7 +330,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                         dependencyOf: [
                             'component:my-other-service'
                         ],
-                        owner: 'owner2',
+                        owner: 'default/owner2',
                         type: 'Memorystore Redis'
                     }
                 },

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
@@ -199,7 +199,7 @@ describe('GoogleSQLDatabaseEntityProvider', () => {
                         dependencyOf: [
                             'component:my-service'
                         ],
-                        owner: 'owner',
+                        owner: 'default/owner',
                         type: 'CloudSQL'
                     }
                 },
@@ -222,7 +222,7 @@ describe('GoogleSQLDatabaseEntityProvider', () => {
                         dependencyOf: [
                             'component:my-other-service'
                         ],
-                        owner: 'owner2',
+                        owner: 'default/owner2',
                         type: 'CloudSQL'
                     }
                 },

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
@@ -65,7 +65,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     dependencyOf: [
                         'component:my-service'
                     ],
-                    owner: 'owner',
+                    owner: 'default/owner',
                     type: 'SQL'
                 }
             })
@@ -111,7 +111,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     dependencyOf: [
                         'component:my-service'
                     ],
-                    owner: 'unknown',
+                    owner: 'default/unknown',
                     type: 'SQL'
                 }
             })
@@ -154,7 +154,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     }]
                 },
                 spec: {
-                    owner: 'owner',
+                    owner: 'default/owner',
                     type: 'SQL'
                 }
             })
@@ -180,7 +180,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     links: [],
                 },
                 spec: {
-                    owner: 'unknown',
+                    owner: 'default/unknown',
                     type: 'SQL'
                 }
             })
@@ -227,7 +227,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     dependencyOf: [
                         'component:my-service'
                     ],
-                    owner: 'owner',
+                    owner: 'default/owner',
                     type: 'SQL'
                 }
             })
@@ -284,7 +284,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     dependencyOf: [
                         'component:my-service'
                     ],
-                    owner: 'owner',
+                    owner: 'default/owner',
                     type: 'redis'
                 }
             })
@@ -329,7 +329,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     dependencyOf: [
                         'component:my-service'
                     ],
-                    owner: 'unknown',
+                    owner: 'default/unknown',
                     type: 'redis'
                 }
             })
@@ -371,7 +371,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     }]
                 },
                 spec: {
-                    owner: 'owner',
+                    owner: 'default/owner',
                     type: 'redis'
                 }
             })
@@ -399,7 +399,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     }]
                 },
                 spec: {
-                    owner: 'unknown',
+                    owner: 'default/unknown',
                     type: 'redis'
                 }
             })
@@ -445,7 +445,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                     dependencyOf: [
                         'component:my-service'
                     ],
-                    owner: 'owner',
+                    owner: 'default/owner',
                     type: 'redis'
                 }
             })

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
@@ -4,6 +4,7 @@ import { sqladmin_v1beta4, redis_v1beta1 } from "googleapis";
 import { ANNOTATION_LOCATION, ANNOTATION_ORIGIN_LOCATION, ResourceEntity } from "@backstage/catalog-model";
 import { GoogleOrganizationProjectEntityProviderConfig } from "../providers/GoogleOrganizationProjectEntityProviderConfig";
 import { google } from '@google-cloud/resource-manager/build/protos/protos';
+import { DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 
 export const ANNOTATION_DATABASE_VERSION = "backtostage.app/google-sql-database-version"
 export const ANNOTATION_DATABASE_INSTALLED_VERSION = "backtostage.app/google-sql-database-installed-version"
@@ -45,7 +46,7 @@ export const defaultDatabaseResourceTransformer: GoogleDatabaseResourceTransform
             links,
         },
         spec: {
-            owner: owner || 'unknown',
+            owner: `${DEFAULT_NAMESPACE}/${owner || 'unknown'}`,
             type: providerConfig.resourceType,
         }
     };
@@ -100,7 +101,7 @@ export const defaultRedisResourceTransformer: GoogleRedisResourceTransformer = (
             links,
         },
         spec: {
-            owner: owner || 'unknown',
+            owner: `${DEFAULT_NAMESPACE}/${owner || 'unknown'}`,
             type: providerConfig.resourceType,
         }
     };


### PR DESCRIPTION
# Description

The Backstage uses the [Entity Namespace](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts#L211) when we don´t provide one. Just PR just change the behavior to always assume a DEFAULT_NAMESPACE
