### PR TITLE
fix: update component namespace to be always DEFAULT_NAMESPACE

### DIFF
--- a/.changeset/fair-pans-tap.md
+++ b/.changeset/fair-pans-tap.md
@@ -1,0 +1,5 @@
+---
+'@backtostage/plugin-catalog-backend-module-gcp': patch
+---
+
+fix unexpected component namespace behavior on use namespaceByProject

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleRedisDatabaseEntityProvider.test.ts
@@ -201,7 +201,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                     },
                     spec: {
                         dependencyOf: [
-                            'component:my-service'
+                            'component:default/my-service'
                         ],
                         owner: 'default/owner',
                         type: 'Memorystore Redis'
@@ -229,7 +229,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                     },
                     spec: {
                         dependencyOf: [
-                            'component:my-other-service'
+                            'component:default/my-other-service'
                         ],
                         owner: 'default/owner2',
                         type: 'Memorystore Redis'
@@ -328,7 +328,7 @@ describe('GoogleRedisDatabaseEntityProvider', () => {
                     },
                     spec: {
                         dependencyOf: [
-                            'component:my-other-service'
+                            'component:default/my-other-service'
                         ],
                         owner: 'default/owner2',
                         type: 'Memorystore Redis'

--- a/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GoogleSQLDatabaseEntityProvider.test.ts
@@ -197,7 +197,7 @@ describe('GoogleSQLDatabaseEntityProvider', () => {
                     },
                     spec: {
                         dependencyOf: [
-                            'component:my-service'
+                            'component:default/my-service'
                         ],
                         owner: 'default/owner',
                         type: 'CloudSQL'
@@ -220,7 +220,7 @@ describe('GoogleSQLDatabaseEntityProvider', () => {
                     },
                     spec: {
                         dependencyOf: [
-                            'component:my-other-service'
+                            'component:default/my-other-service'
                         ],
                         owner: 'default/owner2',
                         type: 'CloudSQL'

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.test.ts
@@ -63,7 +63,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 },
                 spec: {
                     dependencyOf: [
-                        'component:my-service'
+                        'component:default/my-service'
                     ],
                     owner: 'default/owner',
                     type: 'SQL'
@@ -109,7 +109,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 },
                 spec: {
                     dependencyOf: [
-                        'component:my-service'
+                        'component:default/my-service'
                     ],
                     owner: 'default/unknown',
                     type: 'SQL'
@@ -225,7 +225,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 },
                 spec: {
                     dependencyOf: [
-                        'component:my-service'
+                        'component:default/my-service'
                     ],
                     owner: 'default/owner',
                     type: 'SQL'
@@ -282,7 +282,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 },
                 spec: {
                     dependencyOf: [
-                        'component:my-service'
+                        'component:default/my-service'
                     ],
                     owner: 'default/owner',
                     type: 'redis'
@@ -327,7 +327,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 },
                 spec: {
                     dependencyOf: [
-                        'component:my-service'
+                        'component:default/my-service'
                     ],
                     owner: 'default/unknown',
                     type: 'redis'
@@ -443,7 +443,7 @@ describe('defaultDatabaseResourceTransformer', () => {
                 },
                 spec: {
                     dependencyOf: [
-                        'component:my-service'
+                        'component:default/my-service'
                     ],
                     owner: 'default/owner',
                     type: 'redis'

--- a/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
+++ b/plugins/catalog-backend-module-gcp/src/transformers/defaultResourceTransformer.ts
@@ -57,7 +57,7 @@ export const defaultDatabaseResourceTransformer: GoogleDatabaseResourceTransform
 
     if (component) {
         resource.spec.dependencyOf = [
-            `component:${component}`
+            `component:${DEFAULT_NAMESPACE}/${component}`
         ]
     }
 
@@ -113,7 +113,7 @@ export const defaultRedisResourceTransformer: GoogleRedisResourceTransformer = (
 
     if (component) {
         resource.spec.dependencyOf = [
-            `component:${component}`
+            `component:${DEFAULT_NAMESPACE}/${component}`
         ]
     }
 


### PR DESCRIPTION
# Description

The Backstage uses the [Entity Namespace](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts#L211) when we don´t provide one. Just PR just change the behavior to always assume a DEFAULT_NAMESPACE
